### PR TITLE
Refactoring: implementation of mapper and DTO for judoka.

### DIFF
--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaController.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaController.java
@@ -28,7 +28,7 @@ public class JudokaController {
 
     // Add judoka (CREATE)
     @PostMapping("/create")
-    public JudokaModel newJudoka(@RequestBody JudokaModel judoka) {
+    public JudokaDTO newJudoka(@RequestBody JudokaDTO judoka) {
         return judokaService.newJudoka(judoka);
     }
 

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaController.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaController.java
@@ -1,7 +1,5 @@
 package com.cohida.JudokaRegister.Judokas;
-
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 
 @RestController
@@ -16,13 +14,13 @@ public class JudokaController {
 
     // Show all judokas (READ)
     @GetMapping("/list")
-    public List<JudokaModel> showAllJudokas() {
+    public List<JudokaDTO> showAllJudokas() {
         return judokaService.showAllJudokas();
     }
 
     // Find judoka by ID (READ)
     @GetMapping("/list/{id}")
-    public JudokaModel showJudokaById(@PathVariable Long id) {
+    public JudokaDTO showJudokaById(@PathVariable Long id) {
         return judokaService.showJudokaByID(id);
     }
 
@@ -34,7 +32,7 @@ public class JudokaController {
 
     // Update judoka data (UPDATE)
     @PutMapping("/change/{id}")
-    public JudokaModel updateJudoka(@PathVariable Long id, @RequestBody JudokaModel judokaUpdated) {
+    public JudokaDTO updateJudoka(@PathVariable Long id, @RequestBody JudokaDTO judokaUpdated) {
         return judokaService.updateJudoka(id, judokaUpdated);
     }
 

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaDTO.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaDTO.java
@@ -1,0 +1,4 @@
+package com.cohida.JudokaRegister.Judokas;
+
+public class JudokaDTO {
+}

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaDTO.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaDTO.java
@@ -1,4 +1,23 @@
 package com.cohida.JudokaRegister.Judokas;
+import com.cohida.JudokaRegister.Championships.ChampionshipModel;
+import com.cohida.JudokaRegister.Enums.Countries;
+import com.cohida.JudokaRegister.Enums.Obis;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class JudokaDTO {
+
+    private Long id;
+    private String name;
+    private float weight;
+    private int age;
+    private Countries country;
+    private Obis belt;
+    private String rank;
+    private ChampionshipModel championship;
+
 }

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaMapper.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaMapper.java
@@ -1,4 +1,36 @@
 package com.cohida.JudokaRegister.Judokas;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class JudokaMapper {
+
+    public JudokaModel map(JudokaDTO judokaDTO) {
+        JudokaModel judokaModel = new JudokaModel();
+        judokaModel.setId(judokaDTO.getId());
+        judokaModel.setName(judokaDTO.getName());
+        judokaModel.setWeight(judokaDTO.getWeight());
+        judokaModel.setAge(judokaDTO.getAge());
+        judokaModel.setCountry(judokaDTO.getCountry());
+        judokaModel.setBelt(judokaDTO.getBelt());
+        judokaModel.setRank(judokaDTO.getRank());
+        judokaModel.setChampionship(judokaDTO.getChampionship());
+
+        return judokaModel;
+    }
+
+    public JudokaDTO map(JudokaModel judokaModel) {
+        JudokaDTO judokaDTO = new JudokaDTO();
+        judokaDTO.setId(judokaModel.getId());
+        judokaDTO.setName(judokaModel.getName());
+        judokaDTO.setWeight(judokaModel.getWeight());
+        judokaDTO.setAge(judokaModel.getAge());
+        judokaDTO.setCountry(judokaModel.getCountry());
+        judokaDTO.setBelt(judokaModel.getBelt());
+        judokaDTO.setRank(judokaModel.getRank());
+        judokaDTO.setChampionship(judokaModel.getChampionship());
+
+        return judokaDTO;
+    }
+
 }

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaMapper.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaMapper.java
@@ -1,0 +1,4 @@
+package com.cohida.JudokaRegister.Judokas;
+
+public class JudokaMapper {
+}

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaModel.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaModel.java
@@ -17,7 +17,6 @@ public class JudokaModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-
     @Column (name = "id")
     private Long id;
 
@@ -36,11 +35,12 @@ public class JudokaModel {
     @Column (name = "belt")
     private Obis belt;
 
-    // Um judoka pode participar somente de um campeonato por vez
-    @ManyToOne
-    @JoinColumn(name = "championship_id") // FK
-    private ChampionshipModel championship;
+    @Column (name = "rank")
+    private String rank;
 
+    @ManyToOne
+    @JoinColumn(name = "championship_id")
+    private ChampionshipModel championship;
 
 }
 

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaService.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaService.java
@@ -9,9 +9,15 @@ import java.util.Optional;
 public class JudokaService {
 
     private JudokaRepository judokaRepository;
+    private JudokaMapper judokaMapper;
 
     public JudokaService(JudokaRepository judokaRepository) {
         this.judokaRepository = judokaRepository;
+    }
+
+    public JudokaService(JudokaRepository judokaRepository, JudokaMapper judokaMapper) {
+        this.judokaRepository = judokaRepository;
+        this.judokaMapper = judokaMapper;
     }
 
     // List all judokas
@@ -26,8 +32,10 @@ public class JudokaService {
     }
 
     // Create a new judoka
-    public JudokaModel newJudoka(JudokaModel judoka) {
-        return judokaRepository.save(judoka);
+    public JudokaDTO newJudoka(JudokaDTO judokaDTO) {
+        JudokaModel judoka = judokaMapper.map(judokaDTO);
+        judoka = judokaRepository.save(judoka);
+        return judokaMapper.map(judoka);
     }
 
     // Update judoka

--- a/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaService.java
+++ b/src/main/java/com/cohida/JudokaRegister/Judokas/JudokaService.java
@@ -1,9 +1,8 @@
 package com.cohida.JudokaRegister.Judokas;
-
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class JudokaService {
@@ -11,24 +10,23 @@ public class JudokaService {
     private JudokaRepository judokaRepository;
     private JudokaMapper judokaMapper;
 
-    public JudokaService(JudokaRepository judokaRepository) {
-        this.judokaRepository = judokaRepository;
-    }
-
     public JudokaService(JudokaRepository judokaRepository, JudokaMapper judokaMapper) {
         this.judokaRepository = judokaRepository;
         this.judokaMapper = judokaMapper;
     }
 
     // List all judokas
-    public List<JudokaModel> showAllJudokas() {
-        return judokaRepository.findAll();
+    public List<JudokaDTO> showAllJudokas() {
+        List<JudokaModel> judokas = judokaRepository.findAll();
+        return judokas.stream()
+                .map(judokaMapper::map)
+                .collect(Collectors.toList());
     }
 
     // List judoka by ID
-    public JudokaModel showJudokaByID(Long id) {
+    public JudokaDTO showJudokaByID(Long id) {
         Optional<JudokaModel> judokaById = judokaRepository.findById(id);
-        return judokaById.orElse(null);
+        return judokaById.map(judokaMapper::map).orElse(null);
     }
 
     // Create a new judoka
@@ -39,10 +37,13 @@ public class JudokaService {
     }
 
     // Update judoka
-    public JudokaModel updateJudoka(Long id, JudokaModel judokaUpdated) {
-       if(judokaRepository.existsById(id)) {
-           judokaUpdated.setId(id);
-           return judokaRepository.save(judokaUpdated);
+    public JudokaDTO updateJudoka(Long id, JudokaDTO judokaDTO) {
+       Optional<JudokaModel> existingJudoka = judokaRepository.findById(id);
+       if (existingJudoka.isPresent()) {
+           JudokaModel updatedJudoka = judokaMapper.map(judokaDTO);
+           updatedJudoka.setId(id);
+           JudokaModel savedJudoka = judokaRepository.save(updatedJudoka);
+           return judokaMapper.map(savedJudoka);
        }
        return null;
     }


### PR DESCRIPTION
Changes proposed in the PR

- Implementation of JudokaMapper for converting between JudokaModel and JudokaDTO.
- Creation of JudokaDTO containing the necessary fields for external communication.
- Refactoring of JudokaService to use JudokaDTO, eliminating direct exposure of JudokaModel.
- Adjustments in JudokaController to work with JudokaDTO, ensuring a more cohesive and decoupled structure.

These changes aim to improve code organization and separation of concerns, making the application easier to maintain and expand in the future.